### PR TITLE
chore: use sitemap loader for momento blogs

### DIFF
--- a/notebooks/01-load-momento-data.ipynb
+++ b/notebooks/01-load-momento-data.ipynb
@@ -15,11 +15,10 @@
    "source": [
     "import itertools\n",
     "\n",
-    "import requests\n",
     "from bs4 import BeautifulSoup\n",
     "\n",
     "from langchain.embeddings.openai import OpenAIEmbeddings\n",
-    "from langchain.document_loaders import WebBaseLoader, SitemapLoader\n",
+    "from langchain.document_loaders import SitemapLoader\n",
     "from langchain.docstore.document import Document\n",
     "from langchain.text_splitter import TokenTextSplitter\n",
     "\n",
@@ -122,60 +121,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def read_blog_urls(base_url: str = \"https://www.gomomento.com\") -> list[str]:\n",
-    "    response = requests.get(f\"{base_url}/blog\")\n",
-    "    soup = BeautifulSoup(response.text, \"html.parser\")\n",
-    "\n",
-    "    # find all a elements\n",
-    "    a_elements = soup.find_all(\"a\", href=True, recursive=True)\n",
-    "    hrefs = [\n",
-    "        a.get(\"href\") for a in a_elements\n",
-    "        if a.get(\"href\").startswith(\"/blog\") and a.get(\"href\") != \"/blog\"\n",
-    "    ]\n",
-    "    urls = [f\"{base_url}{href}\" for href in hrefs]\n",
-    "\n",
-    "    # dedup and retain the order, see https://peps.python.org/pep-0468/\n",
-    "    return list(dict.fromkeys(urls))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(100,\n",
-       " ['https://www.gomomento.com/blog/episode-4-million-dollar-lines-of-code-engineering-your-cloud-cost-optimization-with-erik-peterson',\n",
-       "  'https://www.gomomento.com/blog/chatting-on-the-edge-integrating-momento-with-netlify-and-vercel',\n",
-       "  'https://www.gomomento.com/blog/unity-chat-demo-quickly-build-a-multiplayer-chat-with-serverless-pub-sub',\n",
-       "  'https://www.gomomento.com/blog/introducing-momento-leaderboards-the-serverless-leaderboard-service',\n",
-       "  'https://www.gomomento.com/blog/momento-cache-is-the-cloud-native-answer-to-elasticache-redis'])"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "blog_urls = read_blog_urls()\n",
-    "len(blog_urls), blog_urls[:5]\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "blog_loader = WebBaseLoader(blog_urls)\n",
-    "blog_loader.parser = parse_content_fn\n"
+    "blog_docs_loader = SitemapLoader(\n",
+    "    web_path=\"https://www.gomomento.com/sitemap.xml\",\n",
+    "    filter_urls=[r\"https://www.gomomento.com/blog.*\"],\n",
+    "    #parsing_function=parse_content_fn\n",
+    ")"
    ]
   },
   {
@@ -194,14 +148,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Fetching pages: 100%|##########| 110/110 [00:10<00:00, 10.05it/s]\n"
+      "Fetching pages: 100%|##########| 123/123 [00:13<00:00,  9.41it/s]\n"
      ]
     }
    ],
@@ -211,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -220,7 +174,7 @@
        "Document(page_content='Momento CacheAccelerate your app, reduce costs, and free your developers.Momento TopicsEnable real-time communication between different parts of a distributed system.Momento Vector IndexA serverless vector index for your AI-enabled applications.#1213Momento LeaderboardsA serverless leaderboard service', metadata={'source': 'https://docs.momentohq.com/', 'loc': 'https://docs.momentohq.com/', 'changefreq': 'weekly', 'priority': '0.5'})"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -231,36 +185,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Fetching pages: 100%|##########| 134/134 [00:20<00:00,  6.61it/s]\n"
+     ]
+    }
+   ],
    "source": [
-    "blogs = blog_loader.load()\n"
+    "blogs = blog_docs_loader.load()\n",
+    "\n",
+    "# Gently preprocess the metadata\n",
+    "def trim_metadata(doc: Document) -> Document:\n",
+    "    metadata = {k: v.strip() for k, v in doc.metadata.items()}\n",
+    "    return Document(page_content=doc.page_content, metadata=metadata)\n",
+    "\n",
+    "blogs = [trim_metadata(doc) for doc in blogs]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'Episode #4 - Million dollar lines of code: Engineering your cloud cost optimization with Erik Peterson — Momento\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\nNameEmail AddressThank you! Your submission has been received!Oops! Something went wrong while submitting the form.Get started with Momento Vector Index today!Get started with Momento Vector Index today!\\n\\n\\nSolutions\\n\\nBy Use CaseBy CategoryBy Team TypeServicesMomento CacheMomento TopicsMomento Vector IndexServicesMomento CacheMomento TopicsMomento Vector IndexBuildUse CasesChatFront-End DevelopmentServerless AppsIndustriesAI/MLGamingIntegrationsDynamoDBMongoDBRedisBuildUse CasesChatFront-end DevelopmentServerless AppsIndustriesAI/MLGamingIntegrationsDynamoDBMongoDBRedisPricingResourcesCase StudiesFAQComplianceResourcesCase StudiesFAQMoCon RecapComplianceBlogDocsCompanyAbout UsJoin our NewsletterCompanyAbout UsJoin our NewsletterDocsLog InContact UsSolutions\\n\\nBy Use CaseBy CategoryBy Team TypeConsoleContact UsEN\\n\\nJPENJPCloseAugust 31, 2023 - 1 Min ReadEpisode #4 - Million dollar lines of code: Engineering your cloud cost optimization with Erik PetersonLearn how to save significantly in your cloud infrastructure.Khawaja Shamsby Khawaja Shams, , by Khawaja Shamsby Khawaja Shams, , PodcastShare\\n\\n\\n\\n\\n\\n\\n\\nSummary\\xa0In episode 4 of the Cache-it podcast, Khawaja invites Erik Peterson, Founder, Director, and CTO/CISO at CloudZero, to discuss the concept of “million dollar lines of code”. The term refers to a single line of code that, when optimized, can lead to significant cost savings in cloud infrastructure. Erik emphasizes the importance of cost optimization in cloud engineering and the need for engineers to consider cost alongside performance and functionality.\\xa0\\u200dThe conversation touches on how engineers often treat cloud resources as abundant due to the ease of provisioning, leading to wasteful spending. Erik suggests that engineers need to flip their mindset from maximizing resource consumption to optimize resource usage.\\xa0\\u200dErik runs through “million dollar lines of code” examples, such as accidentally enabling debug logging that generates excessive data, and altering data access patterns to reduce the size of API calls and lowers costs. He also highlights the importance of aligning cost optimization with a focus on delivering an excellent user experience.\\xa0\\u200dOverall, the conversation dives into the intersection of engineering decisions, cloud costs, and user experience, defining how small code changes can have a profound impact on cost savings while maintaining or even improving system performance.\\xa0\\u200dTo hear more from Erik on this subject, he will be speaking at QCon this year in San Francisco on Wednesday, October 4th.\\xa0\\u200dAbout Erik PetersonErik Peterson is the Founder and CTO of CloudZero and a pioneer in engineering-led cloud cost optimization. He has been building in the cloud since its arrival and has over two decades of software startup experience, with a passion for cost-efficient engineering and excellent margins. Erik is also a believer in Serverless computing, an AWS Ambassador, and a recovering application security survivor. He is an active contributor to the FinOps and Serverless communities and frequently shares his thoughts on cloud economics, DevOps, and security.Khawaja Shamsby Khawaja Shams, , by Khawaja Shamsby by Khawaja Shams, , Author\\n\\n\\n\\n\\n\\nKhawaja ShamsKhawaja is the CEO and Co-Founder of Momento. He is passionate about investing in people, setting a bold vision, and team execution. Khawaja has experience at AWS where he owned DynamoDB, and subsequently owned product and engineering for all 7 of the AWS Media Services. He was awarded the prestigious NASA Early Career Medal for his contributions to the Mars Rovers.Author\\n\\n\\n\\n\\n\\nAuthor\\n\\n\\n\\n\\n\\nPodcastDon’t Miss Our Latest NewsSubscribe to our newsletter and get all the news from Momento.No spam.I agree to receive other communications from Momento. For more information, review our Privacy Policy and Cookie Policy.Thank you!Your submission has been received.Please insert valid email addressFollow Us\\n\\n\\n\\n\\n\\n\\n\\nMore Blog PostsOctober 19, 2023 - 1 Min ReadUnity chat demo: Quickly build a multiplayer chat with serverless pub/subTake advantage of Momento Topics in Unity Game Engine to build multiplayer chat.\\nGamingOctober 18, 2023 - 1 Min ReadIntroducing Momento Leaderboards: the serverless leaderboard serviceIt’s never been easier to build competitive leaderboards.GamingOctober 17, 2023 - 9 Min ReadMomento Cache is the cloud-native answer to ElastiCache RedisGet all the benefits of ElastiCache Redis—and then some.CachingGet going with MomentoTry for FreeContact Us\\n\\n\\n© 2023 momento. All rights reserved.Join Our NewsletterI agree to receive other communications from Momento. For more information, review our Privacy Policy and Cookie Policy.Thank you!Your submission has been received.Please insert valid email addressGet in Touch\\n\\n\\n\\n\\n\\n\\n\\nSolutionsby Team Typeby Team Typeby Company Sizeby Company SizeProductDocsPricingCompanyBlogCareersAbout UsPrivacy PolicyCookie PolicyTerms of ServiceComplianceOpen\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n'"
+       "'3 crucial caching choices: Where, when, and how  — Momento\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\nGet started with Momento Vector Index today!Get started with Momento Vector Index today!Solutions\\n\\nBy Use CaseBy CategoryBy Team TypeServicesMomento CacheMomento TopicsMomento Vector IndexServicesMomento CacheMomento TopicsMomento Vector IndexBuildUse CasesChatFront-End DevelopmentServerless AppsIndustriesAI/MLGamingMedia & EntertainmentIntegrationsDynamoDBMongoDBRedisBuildUse CasesChatFront-end DevelopmentServerless AppsIndustriesAI/MLGamingMedia & EntertainmentIntegrationsDynamoDBMongoDBRedisPricingResourcesCase StudiesFAQComplianceResourcesCase StudiesFAQMoCon RecapComplianceBlogDocsCompanyAbout UsJoin our NewsletterCompanyAbout UsJoin our NewsletterDocsLog InContact UsSolutions\\n\\nBy Use CaseBy CategoryBy Team TypeConsoleContact UsEN\\n\\nJPENJPCloseOctober 13, 2022 - 7 Min Read3 crucial caching choices: Where, when, and how The right questions determine the right caching strategy.\\nAlex DeBrieby Alex DeBrie, , by Alex DeBrieby Alex DeBrie, , CachingBook a demo with us! I agree to Momentocommunications, and Privacy PolicyThank you! Your submission has been received!Oops! Something went wrong while submitting the form.Share\\n\\n\\n\\n\\n\\n\\n\\nCaching is fast. With an in-memory system optimized for key-value access, you can get sub-millisecond p99 response times as measured by the client. Because it’s so fast, caching is fun. It can be the difference between a high-latency experience that frustrates users and a smooth, delightful one that creates repeat customers.\\u200dBut caching can also be a footgun. There are effective ways to use caches, and there are ineffective ways to use caches—and even worse than ineffective caching strategies are harmful caching strategies: ones that confuse your users via stale, inconsistent data or that reduce your application availability.\\u200dSo how can you settle on a caching strategy that gets all the customer delight and none of the footgun? It’s a great question—one I’ll be answering over the course of two blogs. The second installment is where I’ll cover actual strategies and patterns for caching in your application. In this first one, I’ll cover three key choices that will determine your strategy:Where to cache: local vs. remoteWhen to cache: read vs. writeHow to cache: inline vs. aside\\u200dWhere to cache—local vs. remote caching\\u200bWhen thinking about caching, we often jump to a centralized, remote cache that is used like a faster, less durable version of our database. But a cache need not be a separate piece of infrastructure. You can add caching locally to your application, whether on your backend servers or even on your users\\' browsers. When we say \\'local\\' caching, we mean caching that is local to some compute and that is inaccessible from other compute instances.\\u200dIn general, the question of a local vs. remote cache comes down to utility vs. simplicity. A local cache is usually easier to add to an application than pulling in a new piece of infrastructure. Additionally, a new piece of infrastructure brings additional challenges around availability and application uptime that a local cache will generally avoid.\\u200dOn the other hand, a local cache is less useful than a centralized cache. If you are caching on your backend servers, the chance that a request will be served by a machine that has previously cached the data is reduced as the size of your fleet increases. This is even more true due to the ephemerality of modern cloud-based applications. Serverless functions, containers, or instances are becoming more and more short-lived as applications scale up and down dynamically to match demand. A fresh instance of your application has no local cache and thus has no benefit for the initial requests to the application.\\u200dFinally, a local cache can make it harder to manage stale data. When data is altered or deleted, it is easier to make a corresponding update to the cached data in a centralized, remote cache. It is more difficult to indicate updates to cached data that are distributed on local application instances or client browsers. Because of this, a local cache may only work for certain types of cached data or with low time-to-live (TTL) configurations.\\u200dA remote, centralized cache does not have these downsides. It can be used by any servers that are handling a piece of work, making it more broadly useful for your application. Further, remote caches generally have mechanisms to expire data on-demand, allowing your write path to purge data after it has been altered. The downsides of a remote cache are centered on the operational challenges of maintaining a separate piece of infrastructure (though it’s worth noting that Momento Cache solves this problem). If you want a deeper dive on where to cache, check out another blog I wrote: Cut the caching clutter: understanding cache types.\\u200dWhen to cache: read vs. write cachingAgain, you have two choices: cache the data when it is read the first time (often called \"lazy-loading\"), or cache the data when it is written.\\u200dThe most popular caching pattern is likely the read-aside pattern. For this pattern, your application first attempts to read and return data from the cache on a request. If the data is not currently in the cache, the application falls back to the database to read the data. It then stores it in the cache before returning the response so that the retrieved data is available for the next request that needs this data.\\u200dThe opposite pattern is to load your cache following a successful write. After a write succeeds, you would proactively push it to the cache in anticipation of imminent use.\\u200dThe benefits of caching data when it is read are its flexibility and space efficiency. Lazy loading is a flexible pattern that can work for almost any dataset. You can use it to cache individual objects, a result set of multiple objects, or an aggregated value. Whether caching results directly from a database or some results after computation, read-aside caching is easy to implement as you simply cache the final response before returning to the client.\\u200dThis is more difficult when proactively caching on the write side. While caching individual items on writes can be straightforward, it is more difficult to proactively cache result sets or aggregated values as it requires a deeper knowledge of what the read patterns are and how those patterns are affected by writes.\\u200dAdditionally, lazy loading is a more space-efficient use of your cache. Rather than loading data into your cache at write time, regardless of whether it will be read again, you are only caching data once it is read. In many applications, reads of individual data are correlated across time. Something that is read once is more likely to be read soon after. By only caching data once it has been requested at least once, you are optimizing for caching more frequently accessed data.\\u200dThe downsides of caching data when it is read are the slowness of the initial read along with the possibility of returning stale data. Because you are only loading the cache once data is read, it means that each piece of requested data will need to make at least one request through the slower, non-cached path. Depending on your application needs, this may be suboptimal.\\u200dFurther, a pattern that only caches data on the read side will be subject to returning stale data to clients. If the underlying data has changed without a corresponding eviction of the cached data, users could see confusing results. Applications can mitigate this by caching data for a shorter time, though that exacerbates the downside noted above where there is a cache miss.\\u200dHow to cache: inline vs. aside caching\\u200bIn the previous section, we talked about a read-aside cache. An aside cache is the most straightforward type of remote cache, where it stores data explicitly given to it by your service. It usually has simple get and set semantics that can flexibly store any piece of data that you want, but you must store that data specifically. If the data does not exist in the cache, your service is responsible for finding the underlying data elsewhere and updating the cache, if desired.\\u200dOn the other hand, an inline cache is one that is transparent to your service that is calling to retrieve the data. Your application will hit the inline cache directly to retrieve the item. If the cache does not have the requested data, the cache itself will do the work to fetch the data from the upstream data source.\\u200dYou can see why these caches get the name from the architecture diagrams below. The aside cache sits aside your application and is called separately from your data source. Alternatively, the inline cache is used inline with your request to the data source.Aside caches are more common due to their flexibility for nearly any use case. Additionally, they are decoupled from your end datastore and allow you to choose how to handle failures at the caching layer.\\u200dThe benefit of an inline cache is simplicity within your application. Your application doesn\\'t need to worry about multiple different stores and the corresponding logic to fallback to a database in the event of a cache miss.\\u200dThe downside of an inline cache is the reduced availability for your application. You\\'re adding in an additional piece of infrastructure that not only adds caching functionality but also takes responsibility for talking to your database. If your cache goes down, you may have trouble falling back to your database as the cache itself was talking to your database.\\u200dAnother downside of the inline cache is the availability of such services. An inline cache has a tight integration with the downstream data source that it is fronting. As such, someone needs to specifically build a cache that integrates with the primary data source. Because of this, inline caches are generally reserved for generic protocols or as proprietary add-ons to a specific database.\\u200dConclusionConsidering key caching choices is a critical step that will largely determine the caching strategy that’s right for your use case. I’ll cover the actual caching strategies and patterns in the next blog, so stay tuned!\\u200dIf a remote, centralized, read-aside cache with none of the operational challenges sounds perfect, Momento Cache will be a great fit. Even if your needs differ, you can get in touch with them to discuss your use case and find a solution.\\u200dAlex DeBrieby Alex DeBrie, , by Alex DeBrieby by Alex DeBrie, , Author\\n\\n\\n\\n\\n\\nAlex DeBrieAlex DeBrie is an AWS Data Hero and the author of The DynamoDB Book, a comprehensive guide to data modeling with DynamoDB. He works as an independent consultant and helps teams of all shapes and sizes with DynamoDB data modeling and designing serverless architectures. He has been working in the AWS serverless space for years and was an early employee at Serverless, Inc. He lives in Omaha, Nebraska with his wife and four kids.Author\\n\\n\\n\\n\\n\\nAuthor\\n\\n\\n\\n\\n\\nMore Blog PostsJanuary 3, 2024 - 5 Min ReadIntroducing webhooks: Momento Topics goes statelessMake event-driven architectures simpler and more scalable in Momento Topics—now featuring webhooks.WebhooksJanuary 2, 2024 - 9 Min ReadLinear Scaling and the End of the RainbowExplore effective linear scaling strategies for apps. StrategyDecember 28, 2023 - 5 Min ReadScaling Strategies for Cloud ApplicationsMinimize downtime and scale your applications with load balancing and stateless services. StrategyGet going with MomentoTry for FreeContact Us© 2023 momento. All rights reserved.Join Our NewsletterI agree to receive other communications from Momento. For more information, review our Privacy Policy and Cookie Policy.Thank you!Your submission has been received.Please insert valid email addressGet in Touch\\n\\n\\n\\n\\n\\n\\n\\nSolutionsby Team Typeby Team Typeby Company Sizeby Company SizeProductDocsPricingCompanyBlogCareersAbout UsPrivacy PolicyCookie PolicyTerms of ServiceComplianceOpen\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n'"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "blogs[0].page_content\n"
+    "blogs[1].page_content"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,16 +238,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(110, 100, 210)"
+       "(123, 134, 257)"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -296,16 +265,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "3464"
+       "4358"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -332,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -384,7 +353,7 @@
        "ListIndexes.Success(indexes=[])"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -395,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,23 +391,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(Document(page_content=\" Total Cost of Ownership (TCO) matters! Complex pricing models can make it difficult to project costs. We carefully crafted our pricing model with our primary design tenant being simplicity.\\u200dHow is Momento priced? The Momento pricing model is simple and straightforward. A single pricing dimension of $0.50/GB inbound and outbound. Simply the amount of data that moves in and out of Momento Cache. And there's no separate storage charge to worry about.\\u200dWe have a free tier to make it fast for developers to try Momento. Customers get their first 5GB of inbound and outbound for free every month without\", metadata={'title': 'Simple. The way cloud pricing should be. — Momento', 'source': 'https://www.gomomento.com/blog/simple-the-way-cloud-pricing-should-be', 'language': 'en', 'description': 'You don’t need to be lost in a pricing maze. Try Momento Cache for free today.'}),\n",
-       "  0.8547287583351135),\n",
-       " (Document(page_content=\"Pricing and free tier for Momento TopicsServerless is about simplicity in every dimension, including pricing! For on-demand pricing, Momento Cache and Topics costs $0.50/GB transferred, metered in 1 KB increments each time. That's it!Your first 5 GBs transferred each month are free, and you don't need a credit card to get started.Momento services have no hidden charges. You don’t have to pay for storage, replication, or instances. We literally only charge you for data transferred in/out of Momento Cache or Topics services. Everything else is included. Sign up with confidence and\", metadata={'source': 'https://docs.momentohq.com/topics/manage/pricing', 'changefreq': 'weekly', 'loc': 'https://docs.momentohq.com/topics/manage/pricing', 'priority': '0.5'}),\n",
-       "  0.846792459487915),\n",
-       " (Document(page_content=\"'re an indie hacker or an early-stage startup that's looking to save money, Momento is a great fit for you as well.First, Momento Cache has a painless self-service sign up. You can get a Momento authentication token and start writing to your cache in less than five minutes. You don't need to talk to a salesperson or sign an upfront contract. In fact, you don't even need to enter a credit card to enjoy the free tier.Second, Momento Cache has a generous free tier. You get 50 GB free each month (see pricing for details). Our goal is to allow a wide variety of\", metadata={'changefreq': 'weekly', 'source': 'https://docs.momentohq.com/cache/introduction/what-is-serverless-caching', 'loc': 'https://docs.momentohq.com/cache/introduction/what-is-serverless-caching', 'priority': '0.5'}),\n",
-       "  0.8434971570968628),\n",
-       " (Document(page_content=' see how much you can save!Is it really just $.50/GB transferred in and out of Momento services? What else do you charge for?DimensionMomento chargesMemory / Storage$0/GBMulti-AZ replication charges$0/GBSingle sign-on & teams (coming soon)$0/userCan I run a production app for free on Momento Cache and Topics?Absolutely! Our free tier and low usage tiers are just billing. It is the same exact service and features whether you use 40GB/month or 40TB/month. You get all our availability features like multi-AZ replication, hot key protection, and', metadata={'changefreq': 'weekly', 'source': 'https://docs.momentohq.com/cache/manage/pricing', 'priority': '0.5', 'loc': 'https://docs.momentohq.com/cache/manage/pricing'}),\n",
-       "  0.8427053689956665)]"
+       "[(Document(page_content=\" than cutting edge technology advancements, but at Momento, we believe it's a crucial part of the journey. Total Cost of Ownership (TCO) matters! Complex pricing models can make it difficult to project costs. We carefully crafted our pricing model with our primary design tenant being simplicity.\\u200dHow is Momento priced? The Momento pricing model is simple and straightforward. A single pricing dimension of $0.50/GB inbound and outbound. Simply the amount of data that moves in and out of Momento Cache. And there's no separate storage charge to worry about.\\u200dWe have a free tier to make it fast for\", metadata={'loc': 'https://www.gomomento.com/blog/simple-the-way-cloud-pricing-should-be', 'source': 'https://www.gomomento.com/blog/simple-the-way-cloud-pricing-should-be'}),\n",
+       "  0.8557299971580505),\n",
+       " (Document(page_content=\" We believe in a simple, single-dimension pricing model that's easy to reason with as your app grows. We want Momento customers to be able to quickly understand our pricing, estimate the cost, and confidently jump into development to ship their applications with speed.\\u200dIn an increasingly complex world, many cloud services and SaaS offerings have evolved into a maze of options and labyrinthine pricing dimensions that can paralyze customers. This complexity adds friction for customers before they get started on their next big idea—or it results in unforeseen costs. Momento Cache has only one dimension so our customers reach their end goal without distractions or billing surprises.\", metadata={'source': 'https://www.gomomento.com/blog/simple-the-way-cloud-pricing-should-be', 'loc': 'https://www.gomomento.com/blog/simple-the-way-cloud-pricing-should-be'}),\n",
+       "  0.8507596850395203),\n",
+       " (Document(page_content=\"Pricing and free tier for Momento TopicsServerless is about simplicity in every dimension, including pricing! For on-demand pricing, Momento Cache and Topics costs $0.50/GB transferred, metered in 1 KB increments each time. That's it!Your first 5 GBs transferred each month are free, and you don't need a credit card to get started.Momento services have no hidden charges. You don’t have to pay for storage, replication, or instances. We literally only charge you for data transferred in/out of Momento Cache or Topics services. Everything else is included. Sign up with confidence and\", metadata={'changefreq': 'weekly', 'loc': 'https://docs.momentohq.com/topics/manage/pricing', 'priority': '0.5', 'source': 'https://docs.momentohq.com/topics/manage/pricing'}),\n",
+       "  0.8467797636985779),\n",
+       " (Document(page_content=\"'re an indie hacker or an early-stage startup that's looking to save money, Momento is a great fit for you as well.First, Momento Cache has a painless self-service sign up. You can get a Momento authentication token and start writing to your cache in less than five minutes. You don't need to talk to a salesperson or sign an upfront contract. In fact, you don't even need to enter a credit card to enjoy the free tier.Second, Momento Cache has a generous free tier. You get 5 GB free each month (see pricing for details). Our goal is to allow a wide variety of\", metadata={'changefreq': 'weekly', 'source': 'https://docs.momentohq.com/cache/introduction/what-is-serverless-caching', 'loc': 'https://docs.momentohq.com/cache/introduction/what-is-serverless-caching', 'priority': '0.5'}),\n",
+       "  0.8435027003288269)]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -456,7 +425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -474,7 +443,7 @@
        "ListIndexes.Success(indexes=[IndexInfo(name='momento', num_dimensions=1536, similarity_metric=<SimilarityMetric.COSINE_SIMILARITY: 'COSINE_SIMILARITY'>)])"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -485,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -502,44 +471,44 @@
      "output_type": "stream",
      "text": [
       "https://docs.momentohq.com/cache/develop/sdks/dotnet, chunk=1\n",
-      "0.8712294101715088\n",
+      "0.8727020621299744\n",
       "Momento .NET SDKWelcome to the Momento .NET SDK documentation!The Momento .NET SDK is available via the nuget package Momento.Sdk.The source code can be found on GitHub: momentohq/client-sdk-dotnet.Requirements​dotnet runtime and command line tools; after \n",
       "\n",
       "https://docs.momentohq.com/topics/develop/sdks/dotnet, chunk=1\n",
-      "0.8710330724716187\n",
+      "0.8709917664527893\n",
       "Momento .NET SDKWelcome to the Momento .NET SDK documentation!The Momento .NET SDK is available via the nuget package Momento.Sdk.The source code can be found on GitHub: momentohq/client-sdk-dotnet.Requirements​dotnet runtime and command line tools; after \n",
       "\n",
+      "https://docs.momentohq.com/cache/develop/sdks/dotnet/cheat-sheet, chunk=1\n",
+      "0.8559289574623108\n",
+      "Cheat sheet for .NET with Momento CacheIf you need to get going quickly with .NET and Momento Cache, this page contains the basic API calls you'll need. Check the .NET SDK examples for complete, working examples including build configuration files.Install \n",
+      "\n",
       "https://www.gomomento.com/blog/major-release-version-1-0-of-momento-serverless-cache-net-client, chunk=1\n",
-      "0.8558578491210938\n",
-      "Major release: v1.0 of the Momento .NET client — Momento                                  NameEmail AddressThank you! Your submission has been received!Oops! Something went wrong while submitting the form.Get started with Momento Vector Index today!Get sta\n",
+      "0.8520353436470032\n",
+      "Major release: v1.0 of the Momento .NET client — Momento                               Get started with Momento Vector Index today!Get started with Momento Vector Index today!Solutions  By Use CaseBy CategoryBy Team TypeServicesMomento CacheMomento TopicsM\n",
+      "\n",
+      "https://www.gomomento.com/blog/getting-started-with-momento-vector-indexes-in-net, chunk=7\n",
+      "0.8519133925437927\n",
+      "piration dateThe Momento .NET SDKYou’ll need to install the Momento SDK package to use it in your program. It is available on nuget, and can be added via the .NET CLI: dotnet add package Momento.Sdk‍Writing your first Momento Vector Index programHere is th\n",
+      "\n",
+      "https://www.gomomento.com/blog/major-release-version-1-0-of-momento-serverless-cache-net-client, chunk=4\n",
+      "0.8507524132728577\n",
+      "Today we’re excited to announce the 1.0 release of the Momento Cache client for .NET.‍At Momento, simplicity is one of our north stars. We want the Momento experience to be simple and delightful for our users, on both the server side and the client side. O\n",
+      "\n",
+      "https://docs.momentohq.com/cache/develop/integrations/unity-integration, chunk=12\n",
+      "0.8446601033210754\n",
+      " emoji insertion.Setting up the C# script that subscribes to the Momento Topic​In our example code, the magic happens in Assets/TopicsTest.cs, which is based upon the Momento .NET SDK Topic Example.The first thing we need to do is to let our C# script know\n",
+      "\n",
+      "https://www.gomomento.com/blog/getting-started-with-momento-vector-indexes-in-net, chunk=1\n",
+      "0.8440132141113281\n",
+      "Getting Started with Momento Vector Index in .NET — Momento                               Get started with Momento Vector Index today!Get started with Momento Vector Index today!Solutions  By Use CaseBy CategoryBy Team TypeServicesMomento CacheMomento Topi\n",
       "\n",
       "https://www.gomomento.com/blog/unity-chat-demo-quickly-build-a-multiplayer-chat-with-serverless-pub-sub, chunk=6\n",
-      "0.8430825471878052\n",
-      " experience the Momento .NET SDK within Unity, enhancing your C# game development.See serverless pub/sub in action with a quick demoWitness Momento Topics in play! Game clients utilize the pub/sub capabilities to access real-time chat. Messages, including \n",
-      "\n",
-      "https://docs.momentohq.com/leaderboards/develop/api-reference/language_support, chunk=3\n",
-      "0.8409829139709473\n",
-      "Current Status of API support in Momento SDKs\n",
+      "0.8414940237998962\n",
+      " HTTP/2 compatibility through gRPC-Web. All essential DLLS are provided.‍Now you can experience the Momento .NET SDK within Unity, enhancing your C# game development.See serverless pub/sub in action with a quick demoWitness Momento Topics in play! Game cli\n",
       "\n",
       "https://www.gomomento.com/blog/unity-chat-demo-quickly-build-a-multiplayer-chat-with-serverless-pub-sub, chunk=5\n",
-      "0.8377320766448975\n",
-      " set up or configure any external servers or architecture—Momento handles it all.Integrate the Momento .NET SDK with Unity Game EngineDownload MomentoSdkUnity-1.23.0.zip and extract it to your Unity’s “Assets” folder (e.g., in a folder “Assets/MomentoSdkUn\n",
-      "\n",
-      "https://www.gomomento.com/blog/shockingly-simple-tuning-momentos-net-cache-client, chunk=1\n",
-      "0.8322136402130127\n",
-      "Shockingly simple: Tuning Momento’s .NET cache client — Momento                                  NameEmail AddressThank you! Your submission has been received!Oops! Something went wrong while submitting the form.Get started with Momento Vector Index today!\n",
-      "\n",
-      "https://www.gomomento.com/blog/major-release-version-1-0-of-momento-serverless-cache-net-client, chunk=3\n",
-      "0.8314553499221802\n",
-      " Team TypeConsoleContact UsEN  JPENJPCloseNovember 16, 2022 - 3 Min ReadMajor release: v1.0 of the Momento .NET clientCheck out some highlights from our .NET client SDK—and take it for a spin! Chris Priceby Chris Price, , by Chris Priceby Chris Price, , Pr\n",
-      "\n",
-      "https://docs.momentohq.com/cache/getting-started, chunk=12\n",
-      "0.8312716484069824\n",
-      "Python.NETGoPHPJavaRustRubyElixirFAQ​Does Momento deploy any resources into my cloud account?No, it does not. Momento Cache is a fully managed, API-based, serverless service that you call from within your application code.Step 1: Create your API keyStep 2:\n",
-      "\n",
-      "https://docs.momentohq.com/cache/develop/integrations/cloudflare, chunk=21\n",
-      "0.8311951160430908\n",
-      "o HTTP APIUsing the Momento Web SDKConclusion\n",
+      "0.8410884141921997\n",
+      " real-time notification service, is ideal for integrating multiplayer text chat directly into your Unity-powered game. No need to set up or configure any external servers or architecture—Momento handles it all.Integrate the Momento .NET SDK with Unity Game\n",
       "\n"
      ]
     }


### PR DESCRIPTION
The webpage now supports a sitemap loader for the main site. Because
of this we no longer need to scrape the URLs from the blogs page. We
update the notebook to read the blog content using this.
