### PR TITLE
chore: use metadata processing function for reading blogs

### DIFF
--- a/notebooks/01-load-momento-data.ipynb
+++ b/notebooks/01-load-momento-data.ipynb
@@ -116,7 +116,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We also have a trove of documents first from blogs. We'll scrape the links directly from the index page, then use Langchain's WebBaseLoader to scrape the content:"
+    "We also have a trove of documents first from blogs. We can use the same SitemapLoader to read these. To do this we:\n",
+    "- Pass the url of the sitemap to `web_path`\n",
+    "- Additionally filter the urls to only include those paths prefixed with `/blog`\n",
+    "- Strip any leading/trailing whitespace from metadata"
    ]
   },
   {
@@ -125,9 +128,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "def trim_metadata_fn(meta: dict, _content: BeautifulSoup) -> dict:\n",
+    "    meta = {k: v.strip() for k, v in meta.items()}\n",
+    "    return {\"source\": meta[\"loc\"], **meta}\n",
+    "\n",
     "blog_docs_loader = SitemapLoader(\n",
     "    web_path=\"https://www.gomomento.com/sitemap.xml\",\n",
-    "    filter_urls=[r\"https://www.gomomento.com/blog.*\"]\n",
+    "    filter_urls=[r\"https://www.gomomento.com/blog.*\"],\n",
+    "    meta_function=trim_metadata_fn,\n",
     ")"
    ]
   },
@@ -196,14 +204,7 @@
     }
    ],
    "source": [
-    "blogs = blog_docs_loader.load()\n",
-    "\n",
-    "# Gently preprocess the metadata\n",
-    "def trim_metadata(doc: Document) -> Document:\n",
-    "    metadata = {k: v.strip() for k, v in doc.metadata.items()}\n",
-    "    return Document(page_content=doc.page_content, metadata=metadata)\n",
-    "\n",
-    "blogs = [trim_metadata(doc) for doc in blogs]"
+    "blogs = blog_docs_loader.load()"
    ]
   },
   {


### PR DESCRIPTION
Previously we post-processed the metadata outside of the sitemap
loader. Here we refactor to use the `meta_function` parameter to do
this.
