### PR TITLE
chore: for pre-prod, use a DNS name that is already delegated

### DIFF
--- a/infrastructure/bin/infrastructure.ts
+++ b/infrastructure/bin/infrastructure.ts
@@ -34,7 +34,7 @@ if (isDevDeploy) {
   streamlitDemoSubdomain = 'web';
   langserveDemoSubdomain = 'robomo-ls';
 } else {
-  chatDomain = 'mochat-preprod.momentohq.com';
+  chatDomain = 'mochat.preprod.a.momentohq.com';
   streamlitDemoSubdomain = 'web';
   langserveDemoSubdomain = 'robomo-ls';
 }

--- a/infrastructure/lib/robomo-dns.ts
+++ b/infrastructure/lib/robomo-dns.ts
@@ -1,5 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
-import { CfnOutput } from 'aws-cdk-lib';
+import {CfnOutput} from 'aws-cdk-lib';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import {Construct} from 'constructs';
 
@@ -12,14 +12,19 @@ export class RobomoDns extends cdk.Stack {
     },
     cdkStackProps?: cdk.StackProps
   ) {
-      super(scope, id, cdkStackProps);
-      
+    super(scope, id, cdkStackProps);
+
     const hostedZone = new route53.HostedZone(this, 'mvi-chat-hosted-zone', {
-      zoneName: props.chatDomain
+      zoneName: props.chatDomain,
     });
-      
-    
-    new CfnOutput(this, 'mvi-hosted-zone-id-output', { value: hostedZone.hostedZoneId, exportName: 'mvi-hosted-zone-id' });
-    new CfnOutput(this, 'mvi-hosted-zone-name-output', { value: hostedZone.zoneName, exportName: 'mvi-hosted-zone-name' });
+
+    new CfnOutput(this, 'mvi-hosted-zone-id-output', {
+      value: hostedZone.hostedZoneId,
+      exportName: 'mvi-hosted-zone-id',
+    });
+    new CfnOutput(this, 'mvi-hosted-zone-name-output', {
+      value: hostedZone.zoneName,
+      exportName: 'mvi-hosted-zone-name',
+    });
   }
 }


### PR DESCRIPTION
We don't have an easy way to delegate preprod DNS using the previous domain name. This one we already have a preprod hostedzone for, so it will be easier to set up.