### PR TITLE
fix: extract the robo-mo index name used by the langserve version

### DIFF
--- a/infrastructure/lib/mvi-chat-demo-stack.ts
+++ b/infrastructure/lib/mvi-chat-demo-stack.ts
@@ -91,13 +91,16 @@ export class MomentoVectorIndexChatDemoStack extends cdk.Stack {
       momentoApiKeySecret,
     });
 
+    const momentoIndexName = 'momento';
     this.addEcsApp({
       appName: 'langserve-robomo',
       chatSubdomain: props.langserveDemoSubdomain,
       chatDomain: props.chatDomain,
       containerPort: 8080,
       dockerFilePath: '../langchain-robomo',
-      additionalEnvVars: {},
+      additionalEnvVars: {
+        MOMENTO_INDEX_NAME: momentoIndexName,
+      },
       vpc,
       hostedZone,
       openAiApiKeySecret,
@@ -112,7 +115,7 @@ export class MomentoVectorIndexChatDemoStack extends cdk.Stack {
 
       new ScheduledReindexLambda(this, 'scheduled-reindex-lambda', {
         robomoApiEndpoint: `${props.langserveDemoSubdomain}.${props.chatDomain}`,
-        robomoIndexName: 'momento',
+        robomoIndexName: momentoIndexName,
       });
     }
   }


### PR DESCRIPTION
Previously the langserve ECS was using the default index name from the
app, which is not ideal.

Here we pass in the index name to ensure both the app and indexing job
are in sync.
