### PR TITLE
fix: discord bot should cross-post messages in channels with support in the name

### DIFF
--- a/robomo-discord-bot/ecs-code/index.ts
+++ b/robomo-discord-bot/ecs-code/index.ts
@@ -56,14 +56,14 @@ async function main() {
     for (const supportChannel of supportChannels.values()) {
       if (message.channel.id === supportChannel?.id && !message.author.bot) {
         console.log('Support channel message: ' + message.cleanContent);
-  
+
         // get the id of the newest message in the last 11 messages because it's the one that was just posted
         const lastElevenMessages = await message.channel.messages.fetch({limit: 11});
         const fiveMinutes = 5 * 60 * 1000;
         const newestMessageId = lastElevenMessages.reduce((newest, obj) =>
           newest === null ? obj : obj.createdTimestamp > newest.createdTimestamp ? obj : newest
         ).id;
-  
+
         // make sure message is the first from a user in the last 5 minutes (don't want to spam our Slack channel)
         if (
           lastElevenMessages.some(
@@ -92,7 +92,6 @@ async function main() {
         }
       }
     }
-    
   });
 
   const discordToken: string = await getSecret('DiscordBotToken');


### PR DESCRIPTION
Belatedly realized that the official Momento discord server's support channel has an emoji in the name. Updated the discord bot to cross-post messages from any channel with "support" in the name.