### PR TITLE
chore: use more widely available gpt-3.5-turbo model

### DIFF
--- a/langchain-robomo/packages/rag-momento-vector-index/rag_momento_vector_index/chain.py
+++ b/langchain-robomo/packages/rag-momento-vector-index/rag_momento_vector_index/chain.py
@@ -48,7 +48,7 @@ def format_docs(docs: list[Document]) -> str:
     return "\n".join(outputs)
 
 
-model = ChatOpenAI(temperature=0, model="gpt-4-turbo-preview")  # type: ignore
+model = ChatOpenAI(temperature=0, model="gpt-3.5-turbo")  # type: ignore
 chain = {"context": retriever | format_docs, "question": RunnablePassthrough()} | QA_PROMPT | model | StrOutputParser()
 
 


### PR DESCRIPTION
Previously we upgraded the chat model to gpt-4-turbo-preview. This
model is only available to Chat GPT Plus subscribers, so we opt for
the more widely available 3.5-turbo model.
