### PR TITLE
chore: robo-mo should ignore empty messages

### DIFF
--- a/robo-mo-discord-bot/ecs-code/index.ts
+++ b/robo-mo-discord-bot/ecs-code/index.ts
@@ -23,7 +23,7 @@ async function main() {
         channel => channel.name.includes('support') || channel.name.includes('general')
       ) || [];
     for (const supportChannel of supportChannels.values()) {
-      if (message.channel.id === supportChannel?.id && !message.author.bot) {
+      if (message.channel.id === supportChannel?.id && !message.author.bot && message.cleanContent.length > 0) {
         console.log('Support channel message: ' + message.cleanContent);
 
         // get the id of the newest message in the last 11 messages because it's the one that was just posted


### PR DESCRIPTION
When new users join the discord server, there's no message content attached yet they still get cross-posted to Slack.

This PR will add a filter to stop empty messages from being cross-posted.

Used the test server message history to confirm that a new user joining will set `message.cleanContent` to `''` so the filter just checks if the `message.cleanContent` actually has content.